### PR TITLE
FEATURE: add check for selected and dont selected input options

### DIFF
--- a/Classes/ActorTraits/Checks.php
+++ b/Classes/ActorTraits/Checks.php
@@ -103,6 +103,26 @@ trait Checks {
     }
 
     /**
+     * @param $selector
+     * @param $optionText
+     * @Given I should see :selector with :optionText is selected
+     */
+    public function optionIsSelected($selector, $optionText)
+    {
+        $this->seeOptionIsSelected($selector, $optionText);
+    }
+
+    /**
+     * @param $selector
+     * @param $optionText
+     * @Given I see :selector with :optionText is not selected
+     */
+    public function optionIsNotSelected($selector, $optionText)
+    {
+        $this->dontSeeOptionIsSelected($selector, $optionText);
+    }
+
+    /**
      * @Given I should see :expected :selector elements
      * @param int|string $expected
      * @param string $selector


### PR DESCRIPTION
## Description

We have the option to check whether an `input` field of type `checkbox` has been selected or not using the: `seeCheckboxIsChecked` and `dontSeeCheckboxIsChecked` function. However, this does not work for an `Input` field of type `Radio`.

With the function `seeOptionIsSelected` and `dontSeeOptionIsSelected` it is possible to test both `Input` fields of type `Radio` and `Checkbox`. This pull request adds a new helper to use this inside our codeception test.

### Example

```bash
Then I should see "input[value=Mr]" with "Mr" is selected
```